### PR TITLE
various bugfixes + parallelUploads config parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A Node.js package.
 ## Usage
 
 ```
-var ftpDeploy = new require('ftp-deploy')();
+var FtpDeploy = require('ftp-deploy');
+var ftpDeploy = new FtpDeploy();
 
 var config = {
 	username: "username",
@@ -16,7 +17,8 @@ var config = {
 	host: "ftp.someserver.com",
 	port: 21,
 	localRoot: __dirname + "/local-folder",
-	remoteRoot: "/public_html/remote-folder/"
+	remoteRoot: "/public_html/remote-folder/",
+	parallelUploads: 10
 }
 	
 ftpDeploy.deploy(config, function(err) {


### PR DESCRIPTION
- Using new async.map() and async.mapLimit() now
- adding missing leading slash to path in ftpCwd() to prevent problems with relative paths
- added config parameter parallelUploads to be able to control number of parallel uploads for the deployment.
- updated README with new parameter and the non-singleton pattern
