### PR TITLE
add use strict

### DIFF
--- a/ftp-deploy.js
+++ b/ftp-deploy.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const fs = require('fs');
 const path = require('path');
 const util = require('util');


### PR DESCRIPTION
fix `Uncaught SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode` error while using `npm run deploy` using newer versions of npm.

````
$ node deploy
./node_modules/ftp-deploy/ftp-deploy.js:22
        let transferredFileCount = 0;
        ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:373:25)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Module.require (module.js:353:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (./deploy.js:3:17)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
````