### PR TITLE
Use read-stream instead of buffer

### DIFF
--- a/src/ftp-deploy.js
+++ b/src/ftp-deploy.js
@@ -52,7 +52,7 @@ const FtpDeployer = function () {
             // console.log("newDirectory", newDirectory);
             return Promise.mapSeries(fnames, (fname) => {
                 let tmpFileName = upath.join(config.localRoot, relDir, fname);
-                let tmp = fs.readFileSync(tmpFileName);
+                let tmp = fs.createReadStream(tmpFileName);
                 this.eventObject["filename"] = upath.join(relDir, fname);
 
                 this.emit("uploading", this.eventObject);

--- a/test/server.js
+++ b/test/server.js
@@ -1,8 +1,10 @@
 // Quick start
+const path = require("path");
 
 // Using non-standard port
 const port = 2121;
-const homeDir = require("os").homedir() + "/code/nodejs/ftp-deploy/test/remote";
+// const homeDir = require("os").homedir() + "/code/nodejs/ftp-deploy/test/remote";
+const homeDir = path.join(__dirname, "/remote");
 
 const FtpSrv = require("ftp-srv");
 


### PR DESCRIPTION
NodeJS buffer limit is set to 2GB. Upload failed for larger file as the library tried to read the complete file into a buffer. This PR uses a read-stream instead of a buffer to fix this issue 