### PR TITLE
chore: update ftp-srv to 4.3.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "devDependencies": {
         "chai": "^4.2.0",
         "delete": "^1.1.0",
-        "ftp-srv": "^4.2.0",
+        "ftp-srv": "^4.3.4",
         "mocha": "^6.2.1"
     },
     "keywords": [


### PR DESCRIPTION
We've just fixed a critical security vulnerability in `ftp-srv`, and though your dependencies are not pinned, I thought I would bring this into your view directly.

https://github.com/autovance/ftp-srv/security/advisories/GHSA-jw37-5gqr-cf9j