### PR TITLE
Implicitly excluding dot files if they match minimatch patterns & RegExp pattern support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ const config = {
     port: 21,
     localRoot: __dirname + "/local-folder",
     remoteRoot: "/public_html/remote-folder/",
+    // include: /.*/,      // this would upload everything
     // include: ["*", "**/*"],      // this would upload everything except dot files
     include: ["*.php", "dist/*", ".*"],
     // e.g. exclude sourcemaps, and ALL files in node_modules (including dot files)
     exclude: [
         "dist/**/*.map",
         "node_modules/**",
-        "node_modules/**/.*",
         ".git/**",
     ],
     // delete ALL existing files at destination before uploading, if true

--- a/src/ftp-deploy.js
+++ b/src/ftp-deploy.js
@@ -124,13 +124,13 @@ const FtpDeployer = function () {
     // creates list of all files to upload and starts upload process
     this.checkLocalAndUpload = (config) => {
         try {
-            let filemap = lib.parseLocal(
+            const filemap = lib.parseLocal(
                 config.include,
                 config.exclude,
                 config.localRoot,
                 "/"
             );
-            // console.log(filemap);
+
             this.emit(
                 "log",
                 "Files found to upload: " + JSON.stringify(filemap)


### PR DESCRIPTION
## Problem
I ran into a problem with having nested dot directories inside `/node_modules/` (e.g. /node_modules/.bin, /node_modules/get-intrinsic/.github/FUNDING.yml). I wanted to exclude all directories and folders contained in node_modules, but could not formulate a concrete config to do that.

## Proposal
Minimatch's `dot` setting makes it so all dot files are treated the same way as normal files when tested, meaning they don't have to be targeted explicitly. Turning this on for all `exclude` patterns made the most sense to me, as I cannot imagine a situation where I want to exclude all files in a given directory except the hidden ones. This could prove a security risk if one believes they are excluding all dot files from a directory as stated in the README, while they're not.

## Implementation
- 'Exclude' patterns treat dot files like the rest of the files.
- Added RegExp support for patterns.