### PR TITLE
Define `mkDirExists`

### DIFF
--- a/src/lib.js
+++ b/src/lib.js
@@ -129,7 +129,7 @@ function deleteDir(ftp, dir) {
     });
 }
 
-mkDirExists = (ftp, dir) => {
+function mkDirExists(ftp, dir) {
     // Make the directory using recursive expand
     return ftp.mkdir(dir, true).catch((err) => {
         if (err.message.startsWith("EEXIST")) {


### PR DESCRIPTION
When building a project with esbuild 0.18.15 that imports `ftp-deploy`, and running on Node 16, the program will exit because `mkDirExists` is not defined.

Unless I am mistaken, I do not see why mkDirExists needs to be an arrow function and most importantly, where the `mkDirExists` variable is declared before the assignment.

This PR fixes the issue by changing the `mkDirExists` declaration to respect the style of the other functions above.