### PR TITLE
feat: windows path compatibility and path fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "mocha": "^9.1.3"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=12"
             }
         },
         "node_modules/@icetee/ftp": {

--- a/src/ftp-deploy.spec.js
+++ b/src/ftp-deploy.spec.js
@@ -5,13 +5,10 @@ const path = require("upath");
 const fs = require("fs");
 const utils = require("util");
 
-// var assert = require("assert");
-
 const statP = utils.promisify(fs.stat);
 
 const del = require("delete");
 const FtpDeploy = require("./ftp-deploy");
-const { assert } = require("console");
 
 const config = {
     user: "anonymous",

--- a/src/ftp-deploy.spec.js
+++ b/src/ftp-deploy.spec.js
@@ -1,7 +1,7 @@
 "use strict";
 // Mocha tests. https://mochajs.org/#working-with-promises
 
-const path = require("path");
+const path = require("upath");
 const fs = require("fs");
 const utils = require("util");
 
@@ -67,7 +67,7 @@ describe("ftp-deploy.spec: deploy tests", () => {
             })
             .then(() => {
                 // Will reject if file does not exist
-                return statP(remoteDir + "/test-inside-root.txt");
+                return statP(path.join(remoteDir, "test-inside-root.txt"));
             });
     });
     it("should put a dot file", () => {
@@ -79,7 +79,7 @@ describe("ftp-deploy.spec: deploy tests", () => {
             })
             .then(() => {
                 // Will reject if file does not exist
-                return statP(remoteDir + "/.testfile");
+                return statP(path.join(remoteDir, ".testfile"));
             });
     });
 });

--- a/src/lib.js
+++ b/src/lib.js
@@ -1,5 +1,5 @@
 const fs = require("fs");
-const path = require("path");
+const path = require("upath");
 const util = require("util");
 const Promise = require("bluebird");
 

--- a/src/lib.spec.js
+++ b/src/lib.spec.js
@@ -1,11 +1,11 @@
 "use strict";
 
-const path = require("path");
+const path = require("upath");
 var assert = require("assert");
 
 const expect = require("chai").expect;
 
-const lib = require("../src/lib");
+const lib = require("./lib");
 
 describe("canIncludePath", () => {
     it("no patterns excludes a fila", () => {
@@ -81,7 +81,7 @@ describe("dirParseSync", () => {
     it("should traverse test directory", () => {
         const rootDir = path.join(__dirname, "../test/local");
         let exp2 = Object.assign(exp, {
-            "folderA/folderB/FolderC": ["test-inside-c.txt"],
+            [path.join("folderA/folderB/FolderC")]: ["test-inside-c.txt"],
         });
         assert.deepEqual(
             lib.parseLocal(["*"], [".excludeme/**/*"], rootDir, "/"),
@@ -103,8 +103,8 @@ describe("dirParseSync", () => {
 let exp = {
     "/": ["test-inside-root.txt"],
     folderA: ["test-inside-a.txt"],
-    "folderA/folderB": ["test-inside-b.txt"],
-    "folderA/folderB/emptyC/folderD": [
+    [path.join("folderA/folderB")]: ["test-inside-b.txt"],
+    [path.join("folderA/folderB/emptyC/folderD")]: [
         "test-inside-d-1.txt",
         "test-inside-d-2.txt",
     ],

--- a/test/server.js
+++ b/test/server.js
@@ -1,10 +1,9 @@
 const FtpSrv = require("ftp-srv");
+const path = require("upath");
 
 // Using non-standard port
 const port = 2121;
-const homeDir =
-    require("os").homedir() + "/code/projects/ftp-deploy/test/remote";
-// console.log("serving", homeDir);
+const homeDir = path.join(__dirname, "remote");
 
 const options = {
     url: "ftp://127.0.0.1:" + port,


### PR DESCRIPTION
To let the unit tests run on a Windows OS it is necessary to transform the path.

Tasks: 

- use `upath` rather than `path`
- fix path issue in `lib.js` for any OS paths
- fix `homeDir` path in `server.js`