### PR TITLE
reference test server from  __dirname instead of absolute path

### DIFF
--- a/test/server.js
+++ b/test/server.js
@@ -2,8 +2,8 @@ const FtpSrv = require("ftp-srv");
 
 // Using non-standard port
 const port = 2121;
-const homeDir =
-    require("os").homedir() + "/code/projects/ftp-deploy/test/remote";
+
+const homeDir = __dirname + "/remote";
 // console.log("serving", homeDir);
 
 const options = {


### PR DESCRIPTION
The tests are failing because the base dir for the testing ftp is based on the owners absolute path.

This uses __dirname to reference the test server's local path and allows to pass the test in any environment.
