### PR TITLE
Enable parallel uploads

### DIFF
--- a/src/ftp-deploy.js
+++ b/src/ftp-deploy.js
@@ -30,12 +30,27 @@ const FtpDeployer = function () {
         filename: "",
     };
 
-    this.makeAllAndUpload = function (remoteDir, filemap) {
-        let keys = Object.keys(filemap);
-        return Promise.mapSeries(keys, (key) => {
-            // console.log("Processing", key, filemap[key]);
-            return this.makeAndUpload(remoteDir, key, filemap[key]);
+    this.makeAllAndUpload = function (config, filemap) {
+
+        let folders = Object.keys(filemap)
+        .map(key => {
+          return upath.join(config.remoteRoot, key)
         });
+
+        let files   = Object.keys(filemap)
+        .map(key => {
+          return filemap[key].map(file => {
+            if (key === "/") return file
+            return upath.join(key, file)
+          })
+        })
+        .flat();
+
+        // create all the dirs
+        return Promise.mapSeries(folders, folder => {
+          return this.makeDir(folder)
+        })
+        .then(() => this.makeAndUpload(config, "/", files))
     };
 
     this.makeDir = function (newDirectory) {


### PR DESCRIPTION
Recover the old parallelUploads param.

This param enables the parallel upload of files. The default value is 1, so the default behaviour is not changed.

To enable this, I needed to create all the folder structure beforehand, so then it can upload a unique list of files in `makeAndUpload`.

Maybe it would be interesting to add some event in the folder creation.

That is the only change to the default behaviour, I've tried to stay consistent with how files were handled and avoided changing any funcionality other than the already discussed.

Any comments are welcome!